### PR TITLE
Fixes duration and handles interruptions better

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -150,7 +150,7 @@ export type RecordBackType = {
 };
 
 export type RecordingStateType = {
-  state: 'recording' | 'paused' | 'stopped';
+  state: 'recording' | 'paused' | 'interrupted' | 'stopped';
 };
 
 export type PlayBackType = {

--- a/index.ts
+++ b/index.ts
@@ -165,10 +165,10 @@ class AudioRecorderPlayer {
   private _isPlaying: boolean;
   private _hasPaused: boolean;
   private _hasPausedRecord: boolean;
-  private _recorderSubscription: EmitterSubscription;
-  private _recordingStateSubscription: EmitterSubscription;
-  private _playerSubscription: EmitterSubscription;
-  private _playerCallback: (event: PlayBackType) => void;
+  private _recorderSubscription: EmitterSubscription | null;
+  private _recordingStateSubscription: EmitterSubscription | null;
+  private _playerSubscription: EmitterSubscription | null;
+  private _playerCallback: ((event: PlayBackType) => void) | null;
 
   mmss = (secs: number): string => {
     let minutes = Math.floor(secs / 60);
@@ -408,6 +408,8 @@ class AudioRecorderPlayer {
 
       return RNAudioRecorderPlayer.startPlayer(uri, httpHeaders);
     }
+
+    return 'Already playing';
   };
 
   /**
@@ -439,6 +441,8 @@ class AudioRecorderPlayer {
 
       return RNAudioRecorderPlayer.pausePlayer();
     }
+    
+    return 'Already paused';
   };
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -149,6 +149,10 @@ export type RecordBackType = {
   currentMetering?: number;
 };
 
+export type RecordingStateType = {
+  state: 'recording' | 'paused' | 'stopped';
+};
+
 export type PlayBackType = {
   isMuted?: boolean;
   currentPosition: number;
@@ -162,6 +166,7 @@ class AudioRecorderPlayer {
   private _hasPaused: boolean;
   private _hasPausedRecord: boolean;
   private _recorderSubscription: EmitterSubscription;
+  private _recordingStateSubscription: EmitterSubscription;
   private _playerSubscription: EmitterSubscription;
   private _playerCallback: (event: PlayBackType) => void;
 
@@ -214,6 +219,39 @@ class AudioRecorderPlayer {
     if (this._recorderSubscription) {
       this._recorderSubscription.remove();
       this._recorderSubscription = null;
+    }
+  };
+
+  /**
+   * Set listener from native module for recording state.
+   * @returns {callBack((e: RecordBackType): void)}
+   */
+  addRecordingStateListener = (
+    callback: (recordingMeta: RecordingStateType) => void,
+  ): void => {
+    if (Platform.OS === 'android') {
+      this._recordingStateSubscription = DeviceEventEmitter.addListener(
+        'rn-recording-state',
+        callback,
+      );
+    } else {
+      const myModuleEvt = new NativeEventEmitter(RNAudioRecorderPlayer);
+
+      this._recordingStateSubscription = myModuleEvt.addListener(
+        'rn-recording-state',
+        callback,
+      );
+    }
+  };
+
+  /**
+   * Remove listener for recording state.
+   * @returns {void}
+   */
+  removeRecordingStateListener = (): void => {
+    if (this._recordingStateSubscription) {
+      this._recordingStateSubscription.remove();
+      this._recordingStateSubscription = null;
     }
   };
 

--- a/ios/RNAudioRecorderPlayer.swift
+++ b/ios/RNAudioRecorderPlayer.swift
@@ -11,6 +11,7 @@ import QuartzCore
 
 enum RecorderError: LocalizedError {
     case notRecording
+    case alreadyRecording
     case failedToResumeRecording
     case recordingFormatNotAvailable
     case failedToLocateRecordingFile
@@ -23,6 +24,8 @@ enum RecorderError: LocalizedError {
         switch self {
         case .notRecording:
             return "Recorder is not recording"
+        case .alreadyRecording:
+            return "Recorder is already recording"
         case .failedToResumeRecording:
             return "Failed to resume recording"
         case .recordingFormatNotAvailable:
@@ -228,12 +231,12 @@ class RNAudioRecorderPlayer: RCTEventEmitter, AVAudioRecorderDelegate {
     }
 
     private func startNewRecording(path: String, audioSets: [String: Any], meteringEnabled: Bool, completion: @escaping (Result<URL, RecorderError>) -> Void) {
+        guard currentAudioRecorder == nil else { return completion(.failure(.alreadyRecording)) }
+
         _meteringEnabled = meteringEnabled
         guard
             let avFormat: AudioFormatID = avFormat(fromString: audioSets["AVFormatIDKeyIOS"] as? String ?? "alac")
-        else {
-            return completion(.failure(.recordingFormatNotAvailable))
-        }
+        else { return completion(.failure(.recordingFormatNotAvailable)) }
 
         let settings = [
             AVSampleRateKey: audioSets["AVSampleRateKeyIOS"] as? Int ?? 44100,


### PR DESCRIPTION
* Fixes duration by manually tracking how much we've recorded so far.
* Improves interruptions handling by not resetting the session (basically our old patch applied).
* Cleans up the implementation a fair bit. Mostly just common sense stuff without significant changes to the logic itself.
* Dispatches an additional `interrupted` event so that we can handle this case in the app separately from the merely `paused` one.